### PR TITLE
Fix autoconfig bug preventing shutup from working

### DIFF
--- a/DiagROM.s
+++ b/DiagROM.s
@@ -12731,6 +12731,7 @@ DoAutoconfig:
 .WriteFast:
 	move.l	a1,a0			; Set correct Expansionbase
 	move.l	d3,d1
+	move.l	#ec_BaseAddress+ExpansionRom_SIZEOF,d0
 	bsr	.WriteCard
 	rts
 .WriteNoAssign:
@@ -12745,8 +12746,6 @@ DoAutoconfig:
 
 
 .WriteCard:
-	move.l	#ec_BaseAddress+ExpansionRom_SIZEOF,d0
-
 	clr.l	d1
 	move.w	AutoConfWByte-V(a6),d1	; Get data to write
 


### PR DESCRIPTION
@ChuckyGang this fixes a Silly bug where zorro cards are not shut up because WriteNoAssign falls through to WriteCard which loads the "Base Address" register address into D0
This causes autoconfig boards to be assigned rather than shutup

Tested and confirmed in WinUAE by adding 4x 2MB Zorro 2 devices and shutting up half of them under the autoconfig menu
Pre patch: All 4 zorro devices are assigned and respond to memory test
Post patch: Onlt the expected devices respond