### PR TITLE
Autoconfig: Revert next-address when PIC not configured

### DIFF
--- a/DiagROM.s
+++ b/DiagROM.s
@@ -12736,6 +12736,37 @@ DoAutoconfig:
 	rts
 .WriteNoAssign:
 	move.l	a1,a0			; Set correct Expansionbase
+
+.WindBackZorro				; Card was shut-up, revert next-address register.
+	move.b	AutoConfType-V(a6),d0	; Get what type of card
+	cmp.b	#1,AutoConfZorro-V(a6)	; Check if Z3 Card
+	beq	.WindBackZ3
+	cmp.b	#1,d0			; Check if Z2 ROM
+	beq	.WindBackZ2IO
+	clr.l	d0                      ; If we are here it must be a RAM Board!
+	move.b	AutoConfZ2Ram-V(a6),d0
+	swap    d0
+	sub.l   AutoConfSize-V(a6),d0
+	swap    d0	
+	move.b	d0,AutoConfZ2Ram-V(a6)
+	bra .WindBackDone
+.WindBackZ2IO:
+	clr.l	d0
+	move.b	AutoConfZ2IO-V(a6),d0
+	swap    d0
+	sub.l   AutoConfSize-V(a6),d0
+	swap    d0	
+	move.b	d0,AutoConfZ2IO-V(a6)
+	bra .WindBackDone
+.WindBackZ3:
+	clr.l	d0
+	move.w	AutoConfZ3-V(a6),d0
+	swap 	d0
+	sub.l	AutoConfSize-V(a6),d0
+	swap	d0
+	move.w	d0,AutoConfZ3-V(a6)
+
+.WindBackDone:
 	moveq	#ec_Shutup+ExpansionRom_SIZEOF,d0
 	bsr	.WriteCard		; Send shutup
 	move.l	#-2,d0


### PR DESCRIPTION
Hi Again @ChuckyGang :)

Problem:
Now that shutup is working I found that the address variable is incremented anyway, this happens before the board is assigned or told to shut up

Why this is a problem:
If we tell a board to shut up (or there is not sufficient space for the board) the address gets increased by 'AutoConfSize' anyway causing premature exhaustion of zorro space

Example: 
Say you have a config chain that looks like this:
1. 2MB Z2 board
2. 8MB Z2 board (no space, shut up!)
3. 4MB Z2 board

Kickstart will Assign space to boards 1&3 but Diagrom thinks there is no more space when it gets to board 3.

This is a bit of an edge case, not many people are going to have configurations like this because card 2 can never work but for a Z2 ram I'm working on it will attempt to offer smaller memory blocks if told to shut up, and this was preventing me from testing it properly.

I somehow feel like the fix I've done isn't ideal but couldn't think of a better way without reworking large parts of the autoconfig code as the address is incremented early on, but I welcome any feedback if there's a better/easier way to fix this :)
